### PR TITLE
Fix for the missing apicurio.openapi.json file in the

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To install the Apicurio Registry plugin, follow these steps:
 
    ```bash
    cd packages/app 
-   yarn add @simonnepomuk/backage-plugin-apicurio-registry
+   yarn add @simonnepomuk/backstage-plugin-apicurio-registry
    ```
 
 2. Add the proxy config to your `app-config.yaml`:
@@ -35,7 +35,7 @@ To install the Apicurio Registry plugin, follow these steps:
 4. Add the Apicurio Registry Page Widget to your API entities page:
 
    ```tsx
-   import { ApicurioRegistryPage } from '@simonnepomuk/backage-plugin-apicurio-registry';
+   import { ApicurioRegistryPage } from '@simonnepomuk/backstage-plugin-apicurio-registry';
    
    export const entityPage = (
      <EntityLayout>

--- a/plugins/apicurio-registry/README.md
+++ b/plugins/apicurio-registry/README.md
@@ -12,7 +12,7 @@ To install the Apicurio Registry plugin, follow these steps:
 
    ```bash
    cd packages/app 
-   yarn add @simonnepomuk/backage-plugin-apicurio-registry
+   yarn add @simonnepomuk/backstage-plugin-apicurio-registry
    ```
 
 2. Add the proxy config to your `app-config.yaml`:
@@ -35,7 +35,7 @@ To install the Apicurio Registry plugin, follow these steps:
 4. Add the Apicurio Registry Page Widget to your API entities page:
 
    ```tsx
-   import { ApicurioRegistryPage } from '@simonnepomuk/backage-plugin-apicurio-registry';
+   import { ApicurioRegistryPage } from '@simonnepomuk/backstage-plugin-apicurio-registry';
    
    export const entityPage = (
      <EntityLayout>

--- a/plugins/apicurio-registry/package.json
+++ b/plugins/apicurio-registry/package.json
@@ -31,10 +31,9 @@
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test",
     "clean": "backstage-cli package clean",
-    "prepack": "backstage-cli package prepack",
+    "prepack": "backstage-cli package prepack && yarn generate:apicurio-registry-api",
     "postpack": "backstage-cli package postpack",
-    "generate:apicurio-registry-api": "npx openapi-typescript ./apicurio.openapi.json -o src/generated/api/apicurio-registry.d.ts && npx openapi-typescript ./apicurio.openapi.json -o ../../dist-types/plugins/apicurio-registry/src/generated/api/apicurio-registry.ts",
-    "postinstall": "yarn generate:apicurio-registry-api"
+    "generate:apicurio-registry-api": "npx openapi-typescript ./apicurio.openapi.json -o src/generated/api/apicurio-registry.d.ts && npx openapi-typescript ./apicurio.openapi.json -o ../../dist-types/plugins/apicurio-registry/src/generated/api/apicurio-registry.ts"
   },
   "dependencies": {
     "@backstage/core-components": "^0.17.5",
@@ -70,7 +69,8 @@
   "files": [
     "dist",
     "config.d.ts",
-    "docs/**/*"
+    "docs/**/*",
+    "apicurio.openapi.json"
   ],
   "configSchema": "config.d.ts",
   "typesVersions": {


### PR DESCRIPTION
 released package which causes "no such file or directory" in the postinstall
 when adding to backstage, so instead we build up-front and distribute the
 already built typescript.